### PR TITLE
Feature/mapr user

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -56,20 +56,17 @@ if node['hadoop'].key?('yarn_site') && node['hadoop']['yarn_site'].key?('yarn.re
   lwrp_args.push('-RM' => node['hadoop']['yarn_site']['yarn.resourcemanager.hostname'])
 end
 
-# Translate relevant hadoop_mapr attributes into configure.sh args (-u, -U, -g, -G)
-if node['hadoop_mapr'].key?('mapr_user') && node['hadoop_mapr']['mapr_user'].key?('username')
-  lwrp_args.push('-u' => node['hadoop_mapr']['mapr_user']['username'])
-end
-if node['hadoop_mapr'].key?('mapr_user') && node['hadoop_mapr']['mapr_user'].key?('uid')
-  lwrp_args.push('-U' => node['hadoop_mapr']['mapr_user']['uid'])
-end
-if node['hadoop_mapr'].key?('mapr_user') && node['hadoop_mapr']['mapr_user'].key?('group')
-  lwrp_args.push('-g' => node['hadoop_mapr']['mapr_user']['group'])
-end
-if node['hadoop_mapr'].key?('mapr_user') && node['hadoop_mapr']['mapr_user'].key?('gid')
-  lwrp_args.push('-G' => node['hadoop_mapr']['mapr_user']['gid'])
+# Set user/group attributes if hadoop_mapr cookbook created the mapr user
+if node['hadoop_mapr']['create_mapr_user'].to_s == 'true'
+  if node['hadoop_mapr'].key?('mapr_user') && node['hadoop_mapr']['mapr_user'].key?('username')
+    lwrp_args.push('-u' => node['hadoop_mapr']['mapr_user']['username'])
+  end
+  if node['hadoop_mapr'].key?('mapr_user') && node['hadoop_mapr']['mapr_user'].key?('group')
+    lwrp_args.push('-g' => node['hadoop_mapr']['mapr_user']['group'])
+  end
 end
 
+# Set any remaining provided args
 node['hadoop_mapr']['configure_sh']['args'].each do |k, v|
   if v.nil?
     # pass a flag, prevent duplicates


### PR DESCRIPTION
simply sets the `-u` and `-g` args to configure.sh, corresponding to the user and group that the `hadoop_mapr` cookbook created
