### PR TITLE
set default no_autostart attr for configure.sh

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,9 @@ default['hadoop_mapr']['configure_sh']['cldb_mh_list'] = nil
 default['hadoop_mapr']['configure_sh']['zookeeper_list'] = node['fqdn']
 default['hadoop_mapr']['configure_sh']['refresh_roles'] = false
 default['hadoop_mapr']['configure_sh']['client_only_mode'] = false
+# do not autostart services by default
+default['hadoop_mapr']['configure_sh']['no_autostart'] = true
 # Add any additional attributes such as those for disk-setup here
 default['hadoop_mapr']['configure_sh']['args'] = {}
 # default['hadoop_mapr']['configure_sh']['args']['-D'] = '/dev/sdc'
-# default['hadoop_mapr']['configure_sh']['args']['-no-autostart'] = nil
+# default['hadoop_mapr']['configure_sh']['args']['--isvm'] = nil

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -91,6 +91,7 @@ hadoop_mapr_configure node['hadoop_mapr']['configure_sh']['cluster_name'] do
   cldb_mh_list node['hadoop_mapr']['configure_sh']['cldb_mh_list']
   refresh_roles node['hadoop_mapr']['configure_sh']['refresh_roles']
   client_only_mode node['hadoop_mapr']['configure_sh']['client_only_mode']
+  no_autostart node['hadoop_mapr']['configure_sh']['no_autostart']
   args lwrp_args
   action :run
 end


### PR DESCRIPTION
requires https://github.com/caskdata/hadoop_mapr_cookbook/pull/13

Sets `no_autostart` attribute of `configure.sh` to true by default, which I think is a reasonable default for a configure script.  In the context of Coopr, starting services always happens separately in a subsequent task.
