### PR TITLE
Feature/add integration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -185,5 +185,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   # MapR will start up but severely limited by memory
-  config.vm.provision :shell, :inline => '/etc/init.d/mapr-zookeeper start && /etc/init.d/mapr-warden start'
+  # config.vm.provision :shell, :inline => '/etc/init.d/mapr-zookeeper start && /etc/init.d/mapr-warden start'
 end


### PR DESCRIPTION
adding Vagrantfile.

If the warning about memory is ignored and the start command uncommented, it actually does startup and sorta runs. 
