### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,44 @@
-# hadoop_mapr wrapper_cookbook
+# hadoop_mapr wrapper cookbook
 
-Note: This cookbook is under active development and not yet ready for use.
+# Description
+
+This cookbook is a wrapper cookbook for the [Hadoop_mapr cookbook](https://github.com/caskdata/hadoop_mapr_cookbook).  It is a part of [Coopr](https://github.com/caskdata/coopr), which is a general purpose tool that can spin up several types of clusters including MapR Hadoop.  This cookbook provides several initialization recipes for MapR/Hadoop components.  It does not actually start any of the MapR services.  This can be done by wrapping the service resources in the underlying [Hadoop_mapr cookbook](https://github.com/caskdata/hadoop_mapr_cookbook), for example:
+```ruby
+    ruby_block "start warden" do
+      block do
+        resources("mapr-warden").run_action(:start)
+      end 
+    end
+```
+
+Additional information on how to wrap cookbooks in general can be found in the [Hadoop cookbook wiki](https://github.com/caskdata/hadoop_cookbook/wiki/Wrapping-this-cookbook).
 
 # Requirements
 
-# Usage
+This cookbook may work on earlier versions, but these are the minimal tested versions:
+
+* Chef 11.16.4+
+* CentOS 6.6+
+* Ubuntu 12.04+
+
+
+# Cookbook Dependencies
+
+* hadoop_mapr
+* mysql
+* database
 
 # Attributes
 
-# Recipes
+There are no attributes specific to this cookbook, however we set many default attributes for the underlying cookbooks in order to have a reasonably configured MapR cluster.  Be sure to look at the attributes files and override as desired.
 
-# Resources
+# Usage
 
-## configure
-
-### Actions
-
-### Attributes
-
-### Examples
+Include the relevant recipes in your run-list.
 
 # Author
 
 Author:: Cask Data, Inc. (<ops@cask.co>)
-
-# Testing
 
 # License
 


### PR DESCRIPTION
Updating readme for the hadoop_mapr_wrapper cookbook.  I kept it consistent with the [hadoop_wrapper cookbook](https://github.com/caskdata/hadoop_wrapper_cookbook/blob/master/README.md).  (Note that a wrapper cookbook serves as an illustration of how to use the underlying cookbook, and should not need as rigorous documentation).
