### PR TITLE
update mysql dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ This cookbook may work on earlier versions, but these are the minimal tested ver
 
 There are no attributes specific to this cookbook, however we set many default attributes for the underlying cookbooks in order to have a reasonably configured MapR cluster.  Be sure to look at the attributes files and override as desired.
 
+Note: in order to initialize the Hive Metastore database, root credentials must be
+supplied.  Currently, this must be set in `node['mysql']['server_root_password']`
+
 # Usage
 
 Include the relevant [recipes](#recipes) in your run-list.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,12 +4,13 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Wrapper cookbook for caskdata/hadoop_mapr_cookbook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'
 
 depends 'hadoop_mapr'
 
-depends 'mysql', '< 5.0.0'
-depends 'database', '< 2.1.0'
+depends 'mysql', '~> 8.0'
+depends 'database', '~> 6.0'
+depends 'mysql2_chef_gem'
 
 %w(amazon centos debian redhat scientific ubuntu).each do |os|
   supports os


### PR DESCRIPTION
This PR updates the underlying mysql cookbook dependencies, in order to support more recent versions and OSes. Significantly, this cookbook used to rely on the mysql root password attribute set by the old mysql cookbook. The new mysql cookbook no longer sets this attribute, and therefore the root credentials must now be provided to this cookbook.

This is analogous to https://github.com/caskdata/hadoop_wrapper_cookbook/pull/86, but i'm not major version bumping as this cookbook is pre-1.0.