### PR TITLE
use correct hive schema on mapr4.1

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Wrapper cookbook for caskdata/hadoop_mapr_cookbook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.2.1'
 
 depends 'hadoop_mapr'
 

--- a/recipes/hive_metastore_db_init.rb
+++ b/recipes/hive_metastore_db_init.rb
@@ -84,9 +84,10 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
 
     # import hive SQL via execute resource
     # connect via 127.0.0.1 instead of localhost to avoid using an incorrect (default) socket file
+    schema_file = Dir.glob("#{sql_dir}/mysql/hive-schema-*").sort_by! { |s| Gem::Version.new(s.split('/').last.gsub('hive-schema-', '').gsub('.mysql.sql', ''))}.last
     execute 'mysql-import-hive-schema' do # ~FC009
       command <<-EOF
-        mysql --batch -D#{db_name} -h 127.0.0.1 < $(ls -1 hive-schema-* | sort -n | tail -n 1)
+        mysql --batch -D#{db_name} -h 127.0.0.1 < #{schema_file}
         EOF
       sensitive true
       user 'root'
@@ -94,7 +95,6 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
       cwd "#{sql_dir}/mysql"
       environment('MYSQL_PWD' => node['mysql']['server_root_password'])
     end
-
 
     hive_uris.each do |hive_host|
       # database cookbook LWRP to create a user in "remote" instance


### PR DESCRIPTION
https://github.com/caskdata/hadoop_mapr_wrapper_cookbook/pull/13/commits/e2c81a5f6b8de6ca2aaa2fdf14192a31720a3935 introduced an issue when sorting the available hive schema files... selecting 0.9 over 0.14.  This restores the correct numeric sorting.